### PR TITLE
Css adjustment for CUB Hide Names feature.

### DIFF
--- a/src/character/import.css
+++ b/src/character/import.css
@@ -3,7 +3,7 @@
 }
 
 div.ddbCharacterName {
-  display: flex;
+  display: inline-flex;
   flex-direction: row;
   align-items: center;
 }


### PR DESCRIPTION
Fixing this issue: 
![image](https://user-images.githubusercontent.com/19239974/99529748-3a9bf800-2998-11eb-93aa-cdfcef9aed7d.png)
