### PR TITLE
Improved checking for other installed modules

### DIFF
--- a/src/character/import.js
+++ b/src/character/import.js
@@ -745,7 +745,7 @@ export default class CharacterImport extends Application {
       },
     ];
 
-    const daeInstalled = game.modules.get('dae').active && game.modules.get('Dynamic-Effects-SRD').active;
+    const daeInstalled = utils.isModuleInstalledAndActive('dae') && utils.isModuleInstalledAndActive('Dynamic-Effects-SRD');
 
     const importConfig = [
       {
@@ -1039,7 +1039,7 @@ export default class CharacterImport extends Application {
     await Promise.all(actorUpdates);
 
     const daeCopy = game.settings.get("ddb-importer", "character-update-policy-dae-copy");
-    const daeInstalled = game.modules.get('dae').active && game.modules.get('Dynamic-Effects-SRD').active;
+    const daeInstalled = utils.isModuleInstalledAndActive('dae') && utils.isModuleInstalledAndActive('Dynamic-Effects-SRD');
     if (daeCopy && daeInstalled) {
       CharacterImport.showCurrentTask(html, "Importing DAE Effects");
       await DAE.migrateActorDAESRD(this.actor, false);

--- a/src/utils.js
+++ b/src/utils.js
@@ -760,7 +760,7 @@ let utils = {
   },
 
   isModuleInstalledAndActive: (moduleName) => {
-    return moduleName in game.modules && game.modules.get(moduleName).active
+    return moduleName in game.modules && game.modules.get(moduleName).active;
   }
 };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -758,6 +758,10 @@ let utils = {
 
     return 0;
   },
+
+  isModuleInstalledAndActive: (moduleName) => {
+    return moduleName in game.modules && game.modules.get(moduleName).active
+  }
 };
 
 export default utils;


### PR DESCRIPTION
Hi,

This check was failing when the module wasn't installed at all because game.modules.get('dae') was undefined, so it couldn't get the active property out. I created a new utility function to do this check since its already being done for 2 different modules. I have no idea how to test that this code works, but I figured I would send the pull request as soon as possible. I did run the code in my javascript console and it seems to work. 