### PR TITLE
Fix parsing of generic item icons for Other Gear

### DIFF
--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -385,12 +385,13 @@ const DICTIONARY = {
     { name: "Holy Symbol", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/holy-symbol.jpg" },
     { name: "Weapon", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/weapon.jpg" },
     { name: "Arcane Focus", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/arcane-focus.jpg" },
+    { name: "Druidic Focus", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/druidic-focus.jpg" },
     { name: "Ammunition", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/ammunition.jpg" },
     { name: "Poison", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/poison.jpg" },
     { name: "Mount", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/mount.jpg" },
     { name: "Potion", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/potion.jpg" },
-    { name: "Armor", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/armor.jpg" },
-    { name: "Pack", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/pack.jpg" },
+    { name: "Equipment Pack", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/pack.jpg" },
+    // Vehicle (Land)/(Water)
     { name: "Vehicle", img: "https://www.dndbeyond.com/content/1-0-1358-0/skins/waterdeep/images/icons/equipment/vehicle.jpg" },
   ],
   equipment: {

--- a/src/muncher/import.js
+++ b/src/muncher/import.js
@@ -656,9 +656,24 @@ async function getDDBGenericItemImages(download) {
   return Promise.all(itemMap);
 }
 
+async function getDDBGenericLootImages(download) {
+  munchNote(`Fetching DDB Generic Loot icons`);
+  const itemMap = DICTIONARY.genericItemIcons.map(async (item) => {
+    const img = await getImagePath(item.img, 'equipment', item.name, download);
+    let itemIcons = {
+      name: item.name,
+      img: img,
+    };
+    return itemIcons;
+  });
+
+  munchNote("");
+  return Promise.all(itemMap);
+}
 
 export async function getDDBGenericItemIcons(items, download) {
   const genericItems = await getDDBGenericItemImages(download);
+  const genericLoots = await getDDBGenericLootImages(download);
 
   let updatedItems = items.map((item) => {
     // logger.debug(item.name);
@@ -667,9 +682,13 @@ export async function getDDBGenericItemIcons(items, download) {
     if (!excludedItems.includes(item.type) &&
         item.flags &&
         item.flags.ddbimporter &&
-        item.flags.ddbimporter.dndbeyond &&
-        item.flags.ddbimporter.dndbeyond.filterType) {
-      const generic = genericItems.find((i) => i.filterType === item.flags.ddbimporter.dndbeyond.filterType);
+        item.flags.ddbimporter.dndbeyond) {
+      let generic = null;
+      if (item.flags.ddbimporter.dndbeyond.filterType) {
+        generic = genericItems.find((i) => i.filterType === item.flags.ddbimporter.dndbeyond.filterType);
+      } else if (item.flags.ddbimporter.dndbeyond.type) {
+        generic = genericLoots.find((i) => i.name === item.flags.ddbimporter.dndbeyond.type);
+      }
       if (generic && (!item.img || item.img == "" || item.img == "icons/svg/mystery-man.svg")) {
         item.img = generic.img;
       }

--- a/src/parser/inventory/ammunition.js
+++ b/src/parser/inventory/ammunition.js
@@ -87,7 +87,7 @@ let getDamage = (data, magicalDamageBonus) => {
   return result;
 };
 
-export default function parseAmmunition(data) {
+export default function parseAmmunition(data, itemType) {
   /**
    * MAIN parseWeapon
    */
@@ -99,7 +99,7 @@ export default function parseAmmunition(data) {
     flags: {
       ddbimporter: {
         dndbeyond: {
-          type: data.definition.type,
+          type: itemType,
         },
       },
     },

--- a/src/parser/inventory/index.js
+++ b/src/parser/inventory/index.js
@@ -167,7 +167,7 @@ function getWeaponFlags(ddb, data) {
   return flags;
 }
 
-function getItemFromGearTypeIdOne(ddb, data, character) {
+function getItemFromGearTypeIdOne(ddb, data) {
   let item = {};
 
   switch (data.definition.subType) {
@@ -186,12 +186,12 @@ function getItemFromGearTypeIdOne(ddb, data, character) {
   return item;
 }
 
-function otherGear (ddb, data, character) {
+function otherGear (ddb, data) {
   let item = {};
   
   switch (data.definition.gearTypeId) {
     case 1:
-      item = getItemFromGearTypeIdOne(ddb, data, character);
+      item = getItemFromGearTypeIdOne(ddb, data);
       break;
     case 4:
       item = parseLoot(data, "Mount");
@@ -213,7 +213,7 @@ function otherGear (ddb, data, character) {
       item = parseLoot(data, "Equipment Pack");
       break;
     case 18:
-      // TODO change to parseGemstone (consummable)
+      // Change to parseGemstone (consummable) ?
       item = parseLoot(data, "Gemstone");
       break;
     default:
@@ -287,7 +287,7 @@ function parseItem(ddb, data, character) {
           item = parseScroll(data);
           break;
         case "Other Gear":
-          item = otherGear(ddb, data, character);
+          item = otherGear(ddb, data);
           break;
         default:
           logger.warn("Item filterType not implemented for " + data.definition.name);

--- a/src/parser/inventory/index.js
+++ b/src/parser/inventory/index.js
@@ -167,31 +167,6 @@ function getWeaponFlags(ddb, data) {
   return flags;
 }
 
-function otherGear (ddb, data, character) {
-  let item = {};
-  switch (data.definition.subType) {
-    case "Potion":
-      item = parsePotion(data);
-      break;
-    case "Tool":
-      item = parseTool(ddb, data);
-      break;
-    case "Ammunition":
-      item = parseAmmunition(data);
-      break;
-    default:
-      // Final exceptions
-      switch (data.definition.name) {
-        case "Thieves' Tools":
-          item = parseTool(ddb, data, character);
-          break;
-        default:
-          item = parseLoot(data);
-      }
-  }
-  return item;
-}
-
 function getCustomValue(data, character, type) {
   if (!character) return null;
   const characterValues = character.flags.ddbimporter.dndbeyond.characterValues;
@@ -222,6 +197,7 @@ function addCustomValues(ddbItem, foundryItem, character) {
   if (weightOverride) foundryItem.data.weight = weightOverride;
 }
 
+// the filter type "Other Gear" represents the equipment while the other filters represents the magic items in ddb
 function parseItem(ddb, data, character) {
   try {
     // is it a weapon?
@@ -255,12 +231,11 @@ function parseItem(ddb, data, character) {
         case "Scroll":
           item = parseScroll(data);
           break;
-        case "Other Gear": {
-          item = otherGear(ddb, data, character);
-          break;
-        }
-        default:
+        case "Other Gear":
           item = parseLoot(data, character);
+          break;
+        default:
+          logger.warn("Item filterType not implemented for " + data.definition.name);
           break;
       }
     } else {

--- a/src/parser/inventory/index.js
+++ b/src/parser/inventory/index.js
@@ -167,6 +167,61 @@ function getWeaponFlags(ddb, data) {
   return flags;
 }
 
+function getItemFromGearTypeIdOne(ddb, data, character) {
+  let item = {};
+
+  switch (data.definition.subType) {
+    case "Potion":
+      item = parsePotion(data, data.definition.subType);
+      break;
+    case "Tool":
+      item = parseTool(ddb, data, data.definition.subType);
+      break;
+    case "Ammunition":
+      item = parseAmmunition(data, data.definition.subType);
+      break;
+    default:
+      item = parseLoot(data, data.definition.subType);
+  }
+  return item;
+}
+
+function otherGear (ddb, data, character) {
+  let item = {};
+  
+  switch (data.definition.gearTypeId) {
+    case 1:
+      item = getItemFromGearTypeIdOne(ddb, data, character);
+      break;
+    case 4:
+      item = parseLoot(data, "Mount");
+      break;
+    case 5:
+    item = parsePotion(data, "Poison");
+      break;
+    case 6:
+    item = parsePotion(data, "Potion");
+      break;
+    case 11:
+      item = parseTool(ddb, data, "Tool");
+      break;
+    case 12:
+    case 17:
+      item = parseLoot(data, "Vehicle");
+      break;
+    case 16:
+      item = parseLoot(data, "Equipment Pack");
+      break;
+    case 18:
+      // TODO change to parseGemstone (consummable)
+      item = parseLoot(data, "Gemstone");
+      break;
+    default:
+      logger.warn("Other Gear type missing from " + data.definition.name);
+  }
+  return item;
+}
+
 function getCustomValue(data, character, type) {
   if (!character) return null;
   const characterValues = character.flags.ddbimporter.dndbeyond.characterValues;
@@ -206,7 +261,7 @@ function parseItem(ddb, data, character) {
       switch (data.definition.filterType) {
         case "Weapon": {
           if (data.definition.type === "Ammunition" || data.definition.subType === "Ammunition") {
-            item = parseAmmunition(data);
+            item = parseAmmunition(data, "Ammunition");
           } else {
             const flags = getWeaponFlags(ddb, data);
             item = parseWeapon(data, character, flags);
@@ -226,13 +281,13 @@ function parseItem(ddb, data, character) {
           item = parseStaff(data, character);
           break;
         case "Potion":
-          item = parsePotion(data);
+          item = parsePotion(data, data.definition.type);
           break;
         case "Scroll":
           item = parseScroll(data);
           break;
         case "Other Gear":
-          item = parseLoot(data, character);
+          item = otherGear(ddb, data, character);
           break;
         default:
           logger.warn("Item filterType not implemented for " + data.definition.name);

--- a/src/parser/inventory/loot.js
+++ b/src/parser/inventory/loot.js
@@ -43,6 +43,42 @@ const getItemType = (data) => {
   return itemType === undefined ? "loot" : itemType;
 };
 
+const getItemSubType = (data) => {
+  let itemSubType;
+
+  switch (data.definition.gearTypeId) {
+    case 1:
+      itemSubType = data.definition.subType;
+      break;
+    case 4:
+      itemSubType = "Mount";
+      break;
+    case 5:
+      itemSubType = "Poison";
+      break;
+    case 6:
+      itemSubType = "Potion";
+      break;
+    case 11:
+      itemSubType = "Tool";
+      break;
+    case 12:  // Vehicle (Land)
+    case 17:  // Vehicle (Water)
+      itemSubType = "Vehicle";
+      break;
+    case 16:
+      itemSubType = "Equipment Pack";
+      break;
+    case 18:
+      itemSubType = "Gemstone";
+      break;
+    default:
+      logger.warn("Item subType missing for loot item " + data.definition.name);
+  }
+  
+  return itemSubType;
+};
+
 export default function parseLoot(data) {
   /**
    * MAIN parseLoot
@@ -54,7 +90,7 @@ export default function parseLoot(data) {
     flags: {
       ddbimporter: {
         dndbeyond: {
-          type: data.definition.type,
+          type: getItemSubType(data),
         },
       },
     },

--- a/src/parser/inventory/loot.js
+++ b/src/parser/inventory/loot.js
@@ -43,43 +43,7 @@ const getItemType = (data) => {
   return itemType === undefined ? "loot" : itemType;
 };
 
-const getItemSubType = (data) => {
-  let itemSubType;
-
-  switch (data.definition.gearTypeId) {
-    case 1:
-      itemSubType = data.definition.subType;
-      break;
-    case 4:
-      itemSubType = "Mount";
-      break;
-    case 5:
-      itemSubType = "Poison";
-      break;
-    case 6:
-      itemSubType = "Potion";
-      break;
-    case 11:
-      itemSubType = "Tool";
-      break;
-    case 12:  // Vehicle (Land)
-    case 17:  // Vehicle (Water)
-      itemSubType = "Vehicle";
-      break;
-    case 16:
-      itemSubType = "Equipment Pack";
-      break;
-    case 18:
-      itemSubType = "Gemstone";
-      break;
-    default:
-      logger.warn("Item subType missing for loot item " + data.definition.name);
-  }
-  
-  return itemSubType;
-};
-
-export default function parseLoot(data) {
+export default function parseLoot(data, itemType) {
   /**
    * MAIN parseLoot
    */
@@ -90,7 +54,7 @@ export default function parseLoot(data) {
     flags: {
       ddbimporter: {
         dndbeyond: {
-          type: getItemSubType(data),
+          type: itemType,
         },
       },
     },

--- a/src/parser/inventory/potion.js
+++ b/src/parser/inventory/potion.js
@@ -87,7 +87,7 @@ let getDamage = (data, actionType) => {
   return damage;
 };
 
-export default function parsePotion(data) {
+export default function parsePotion(data, itemType) {
   /**
    * MAIN parseWeapon
    */
@@ -98,7 +98,7 @@ export default function parsePotion(data) {
     flags: {
       ddbimporter: {
         dndbeyond: {
-          type: data.definition.type,
+          type: itemType,
         },
       },
     },

--- a/src/parser/inventory/tool.js
+++ b/src/parser/inventory/tool.js
@@ -78,7 +78,7 @@ let getUses = (data) => {
   }
 };
 
-export default function parseTool(ddb, data) {
+export default function parseTool(ddb, data, itemType) {
   /**
    * MAIN parseTool
    */
@@ -89,7 +89,7 @@ export default function parseTool(ddb, data) {
     flags: {
       ddbimporter: {
         dndbeyond: {
-          type: data.definition.type,
+          type: itemType,
         },
       },
     },


### PR DESCRIPTION
Fix parsing for `Other Gear` filter type. This affects DnD Beyond Equipment imports (not Magic Items). The key `flags.ddbimporter.dndbeyond.type` now stores the specific type unlike the Magic Items type who is stored in the filterType flags.

The parsing now fetchs the appropriate icon image when importing Equipment from DnD Beyond.

![fix](https://user-images.githubusercontent.com/32679594/101747111-963e3a80-3a99-11eb-8529-a19d15394ed2.png)
