### PR TITLE
Remove un-needed dependency section

### DIFF
--- a/module.json
+++ b/module.json
@@ -29,13 +29,6 @@
     }
   ],
   "systems": ["dnd5e"],
-
-"dependencies": [
-    {
-      "name": "dnd5e",
-      "type": "system"
-    }
-  ],
   "esmodules": ["src/index.js"],
   "styles": [
     "./css/module-settings.css",


### PR DESCRIPTION
When enabling this module, it asks to enable dependencies. But there are no real module dependencies to enable, and by the time you see this message, you are already running a system. The `systems` field in the modules.json file should be enough since it will restrict even seeing this module as an option to enable to only when the system module is `dnd5e`.