### PR TITLE
Fix character avatar permission from player's role

### DIFF
--- a/src/character/import.js
+++ b/src/character/import.js
@@ -316,8 +316,9 @@ export default class CharacterImport extends Application {
   async updateImage(html, data) {
     // updating the image?
     let imagePath = this.actor.img;
+    const userHasPermission = !(game.settings.get("ddb-importer", "restrict-to-trusted") && !game.user.isTrusted);
     if (
-      game.user.isTrusted &&
+      userHasPermission &&
       data.avatarUrl &&
       data.avatarUrl !== "" &&
       (imagePath.indexOf("mystery-man") !== -1 || game.settings.get("ddb-importer", "character-update-policy-image"))


### PR DESCRIPTION
This commit resolves the first user case (first row below): When the `restrict-to-trusted` was unchecked and someone with a `Player's` role (with appropriate permissions)  tried to import the avatar image if failed.

| restrict-to-trusted | isTrusted | Permission to upload image |
|---------------------|-----------|----------------------------|
| false               | false     | GRANTED                    |
| false               | true      | GRANTED                    |
| true                | false     | **DENIED**                    |
| true                | true      | GRANTED                    |

This fix is based on the above truth table.