### PR TITLE
Default to mystery man icon when querying iconizer

### DIFF
--- a/src/muncher/import.js
+++ b/src/muncher/import.js
@@ -653,7 +653,7 @@ async function getIconizerIcons(items) {
     items.forEach((item) => {
       const icon = icons.find((icon) => icon.name === item.name);
       if (icon && (!item.img || item.img == "" || item.img == "icons/svg/mystery-man.svg")) {
-        item.img = icon.img;
+        item.img = icon.img || "icons/svg/mystery-man.svg";
       }
     });
   } catch (exception) {


### PR DESCRIPTION
Previously, when querying iconizer, if `icon.img` was undefined, the default mystery man icon in the item would get
replaced with `undefined`. This would break the logic for updating the icon with the D&D Beyond icons later down the
line when adding the NPCs to the compendium. The fix I made was simply to default to mystery-man when iconizer is used.