### PR TITLE
missing closing div tag, it was causing all the items to be nested

### DIFF
--- a/handlebars/sources.hbs
+++ b/handlebars/sources.hbs
@@ -14,6 +14,7 @@
               name="{{this.id}}"
               data-section="{{this.label}}">
         {{this.label}} ({{this.acronym}})
+      </div>
       {{/each}}
       <hr>
      </div>


### PR DESCRIPTION
im somewhat surprised that this didnt cause any problems, but each source item was nested under the previous in html.  because they were all div tags,i think it worked fine, but it also in theory caused some performance on the DOM.    In any event, this should clean that up.