### PR TITLE
Compendium configuration flex layout lineup

### DIFF
--- a/handlebars/compendium.hbs
+++ b/handlebars/compendium.hbs
@@ -8,7 +8,7 @@
       {{#each compendiums}}
       <div class="form-group">
         <h3><label for="cars">{{this.name}}</label></h3>
-        <select name="{{this.setting}}" id="{{this.setting}}" style="flex: 0 1 auto">
+        <select name="{{this.setting}}" id="{{this.setting}}" style="flex: 55%">
           {{#each this.compendiums}}
             <option value="{{@key}}" {{#if this.selected}}selected{{/if}}>{{this.label}}</option>
           {{/each}}


### PR DESCRIPTION
I've seen this issue mentioned a few times
![image](https://user-images.githubusercontent.com/14927087/122693425-125acd00-d1f7-11eb-867a-3fcae784e12a.png)

and I decided to see if I could figure out the problem and if I could fix it.

Changing this setting to `55%` instead of `0 1 auto` seems to do the trick. (I didn't actually build this and test it, I just manually modified the value for all the fields in the browser, so I'm only 98% sure this will do what I expect)

Here's what it looks like with all fields set to 55%:
![image](https://user-images.githubusercontent.com/14927087/122693569-a62c9900-d1f7-11eb-8114-e9baea92d655.png)

Each drop-down menu is only slightly wider than it used to be:
![image](https://user-images.githubusercontent.com/14927087/122693606-b9d7ff80-d1f7-11eb-904b-7d0e9146f0b4.png)

The reason the widths were different was because all the fields except for the monsters field were designated as item type, so they all have `[Dynamic-Effects-SRD] DAE SRD Midi-collection` as an option in their drop-down menu, so the flex style was setting the width for all the fields, except for monsters, to be wide enough to fit that option.

Shortcomings of this fix: I didn't figure out how to actually connect the differing fields flex attributes, so if there comes an option longer than the Midi-collection option, it will cause all the fields associated with that type to widen, and leave the other type's fields behind at just 55%.