### PR TITLE
modify check for replaceAll to use typeof instead of inspecting userAgent

### DIFF
--- a/src/parser/templateStrings.js
+++ b/src/parser/templateStrings.js
@@ -223,7 +223,7 @@ function replaceTag(match, p1, p2, p3, offset, string) {
 
 function parseTags(text) {
   if (!srdRules) return text;
-  // chrome, chromium, and electron app do not support replaceAll
+  // older chrome/chromium and electron app do not support replaceAll
   if (typeof text.replaceAll !== "function") {
     return text;
   }

--- a/src/parser/templateStrings.js
+++ b/src/parser/templateStrings.js
@@ -223,8 +223,8 @@ function replaceTag(match, p1, p2, p3, offset, string) {
 
 function parseTags(text) {
   if (!srdRules) return text;
-  // electron app does not support replaceAll
-  if ((/electron/i).test(navigator.userAgent)) {
+  // chrome, chromium, and electron app do not support replaceAll
+  if (typeof text.replaceAll !== "function") {
     return text;
   }
   const tagRegEx = /\[(.*)](.*)\[\/(.*)]/g;


### PR DESCRIPTION
Chrome and Chromium don't have replaceAll either, so I modified the check to look for the existence of the function instead of checking the userAgent string to allow the module to work under those browsers as well.
