### PR TITLE
Add check to validate artificer class exists before trying to access

### DIFF
--- a/src/character/extras.js
+++ b/src/character/extras.js
@@ -396,16 +396,14 @@ export async function characterExtras(html, characterData, actor) {
       // homunculus servant
       if (creatureFlags.includes("MHPBAL")) {
         const artificer = ddbCharacter.classes.find((klass) => klass.definition.name === "Artificer");
-        if (artificer)
-        {
+        if (artificer) {
           mock.averageHitPoints = parseInt(artificer.level);
         }
       }
 
       if (creatureFlags.includes("AHM")) {
         const artificer = ddbCharacter.classes.find((klass) => klass.definition.name === "Artificer");
-        if (artificer)
-        {
+        if (artificer) {
           mock.averageHitPoints = parseInt(5 * artificer.level);
         }
       }

--- a/src/character/extras.js
+++ b/src/character/extras.js
@@ -396,12 +396,18 @@ export async function characterExtras(html, characterData, actor) {
       // homunculus servant
       if (creatureFlags.includes("MHPBAL")) {
         const artificer = ddbCharacter.classes.find((klass) => klass.definition.name === "Artificer");
-        mock.averageHitPoints = parseInt(artificer.level);
+        if (artificer)
+        {
+          mock.averageHitPoints = parseInt(artificer.level);
+        }
       }
 
       if (creatureFlags.includes("AHM")) {
         const artificer = ddbCharacter.classes.find((klass) => klass.definition.name === "Artificer");
-        mock.averageHitPoints = parseInt(5 * artificer.level);
+        if (artificer)
+        {
+          mock.averageHitPoints = parseInt(5 * artificer.level);
+        }
       }
 
       if (creatureFlags.includes("MHPAIM")) {


### PR DESCRIPTION
Check if artificer exists before trying to access its component to avoid an exception when importing companions
![image](https://user-images.githubusercontent.com/9066690/154831928-7886e36c-f122-41c8-acc1-829026143755.png)
![image](https://user-images.githubusercontent.com/9066690/154831931-5239dcff-1c8b-4c93-8845-b9b6ec14985a.png)
