### PR TITLE
Ensure global bonus is stored as a string.

### DIFF
--- a/src/parser/character/globalBonuses.js
+++ b/src/parser/character/globalBonuses.js
@@ -46,7 +46,7 @@ export function getGlobalBonusAttackModifiers(lookupTable, data, character) {
   ["attack", "damage"].forEach((fvttType) => {
     if (lookupResults[fvttType].diceString === "") {
       if (lookupResults[fvttType].sum !== 0) {
-        result[fvttType] = lookupResults[fvttType].sum;
+        result[fvttType] = `${lookupResults[fvttType].sum}`;
       }
     } else {
       result[fvttType] = lookupResults[fvttType].diceString;


### PR DESCRIPTION
Setting a value to a number works at first but breaks active effects that wish to add to that value.