### PR TITLE
Add register settings for "early" settings

### DIFF
--- a/src/hooks/ready/registerGameSettings.js
+++ b/src/hooks/ready/registerGameSettings.js
@@ -148,6 +148,10 @@ export default function () {
     type: DDBDynamicUpdateSetup,
     restricted: true,
   });
+  
+  for (const [name, data] of Object.entries(SETTINGS.GET_DEFAULT_SETTINGS(true))) {
+    game.settings.register(SETTINGS.MODULE_ID, name, data);
+  }
 
   for (const [name, data] of Object.entries(SETTINGS.GET_DEFAULT_SETTINGS())) {
     game.settings.register(SETTINGS.MODULE_ID, name, data);


### PR DESCRIPTION
This was causing this file to break when checking for `developer-mode` below. It seems that unregistered settings are being unset.
![image](https://user-images.githubusercontent.com/7295817/211286332-6cbdb834-2943-4769-92ed-6851f75ba26a.png)
