### PR TITLE
fixed arcane ward triggering twice

### DIFF
--- a/macros/feats/arcaneWard.js
+++ b/macros/feats/arcaneWard.js
@@ -66,7 +66,7 @@ if (args[0].macroPass === "preActiveEffects" && args[0].item?.system.school === 
         content: `${lastArg.originItem.name} absorbs ${absorbed} of ${damage} points of damage.<br> Hp -> ${newHP}<br>Wardstength -> ${wardStrength - absorbed}`,
         speaker
       });
-      lastArg.updates.system.attributes.hp.value = newHP;
+      lastArg.updates.system.attributes.hp.value = oldHP; //Set hp to oldHP so the uses update, won't be interpreted as taking damage.
       await lastArg.targetActor.updateEmbeddedDocuments("Item", [{
         _id: hpItem._id,
         system: {
@@ -75,6 +75,7 @@ if (args[0].macroPass === "preActiveEffects" && args[0].item?.system.school === 
           }
         }
       }]);
+      lastArg.updates.system.attributes.hp.value = newHP; //Hp is actually set here.
     }
   }
   return true;


### PR DESCRIPTION
Arcane ward was triggering, it's onTargetUpdate macro twice.

![Arcane ward bug](https://user-images.githubusercontent.com/36708961/227286891-a38ca4eb-3bc5-466e-9a7c-a4d9d0a7bfa0.png)
Because the hpItem update, sees updates.system.attributes.hp.value, being less than the current hp of the actor. 