### PR TITLE
fix #472 - add new pack to folder by replicating what core does

### DIFF
--- a/src/lib/CompendiumHelper.js
+++ b/src/lib/CompendiumHelper.js
@@ -216,8 +216,8 @@ const CompendiumHelper = {
           label,
           name,
           package: packageType,
-          folder: folderId,
         });
+        if (folderId) await newCompendium.setFolder(folderId);
         return {
           compendium: newCompendium,
           created: true


### PR DESCRIPTION
Fix the bug by copying what core Foundry does in `CompendiumDirectory#_onCreateEntry`: calling `setFolder` after the pack is created.