### PR TITLE
Fix Armorer special weapons not correctly importing as Items

### DIFF
--- a/src/parser/features/DDBAttackAction.js
+++ b/src/parser/features/DDBAttackAction.js
@@ -10,8 +10,10 @@ export default class DDBAttackAction extends DDBAction {
     "Psychic Blades: Attack (STR)",
     "Psychic Blades: Bonus Attack (DEX)",
     "Psychic Blades: Bonus Attack (STR)",
-    "Thunder Gauntlets",
-    "Lightning Launcher",
+    "Guardian Armor: Thunder Gauntlets",
+    "Infiltrator Armor: Lightning Launcher",
+    "Guardian Armor: Thunder Gauntlets (STR)",
+    "Infiltrator Armor: Lightning Launcher (DEX)",
   ];
 
   _init() {


### PR DESCRIPTION
Update DDBAttackAction.js with the correct designation of the Thunder Gauntlets and Lightning Launcher. They have the name of the armor in front of their names, much like the Psychic Blades do.