### PR TITLE
Update DDBHelper.js - Add null check to ddb in DDBHelper.getCustomValue()

### DIFF
--- a/src/lib/DDBHelper.js
+++ b/src/lib/DDBHelper.js
@@ -779,7 +779,7 @@ const DDBHelper = {
   },
 
   getCustomValue(foundryItem, ddb, type) {
-    const characterValues = ddb.character?.characterValues;
+    const characterValues = ddb?.character?.characterValues;
     if (!characterValues) return null;
     const customValue = characterValues.filter(
       (value) =>


### PR DESCRIPTION
During munch of backgrounds this function is called with ddb = null. This causes an Exception: "TypeError: Cannot read properties of null (reading 'character')" and the Background munch fails to succeed. This fix allows Background munch to work again by properly guarding against attempts to deference a null value.

![image](https://github.com/MrPrimate/ddb-importer/assets/116830/cf9e1889-0380-4991-ab0a-5f740ef886bf)
