### PR TITLE
Update wardingBond.js

### DIFF
--- a/macros/spells/wardingBond.js
+++ b/macros/spells/wardingBond.js
@@ -18,7 +18,7 @@ async function setWardingBondHook() {
       caster.actor.applyDamage(hpChange);
     }
     if (newHP === 0) {
-      const effectIds = targetActor.effects.filter((e) => e.label === "Warding Bond").map((t) => t.id);
+      const effectIds = targetActor.effects.filter((e) => e.name === "Warding Bond").map((t) => t.id);
       await targetActor.deleteEmbeddedDocuments("ActiveEffect", effectIds);
     }
   });


### PR DESCRIPTION
.label is deprecated and breaks in v12/3.3.1 dnd5e.  This is my first attempt at doing this, sorry if its the wrong way to do it, definitely make sure I didn't mess anything up.  