### PR TITLE
minor cpr fix

### DIFF
--- a/src/effects/external/ChrisPremadesHelper.js
+++ b/src/effects/external/ChrisPremadesHelper.js
@@ -530,24 +530,13 @@ ${chat}
 
 
       if (restrictedItem.requiredEquipment) {
-        for (const requiredEquipment of restrictedItem.requiredEquipment) {
-          const itemMatch = documents.some((d) => (d.flags.ddbimporter?.chrisPreEffectName ?? ChrisPremadesHelper.getOriginalName(d)) === requiredEquipment && DICTIONARY.types.inventory.includes(d.type));
-          if (!itemMatch) continue;
-        }
-      }
-
-      if (restrictedItem.requiredFeature) {
-        for (const requiredFeature of restrictedItem.requiredFeature) {
-          const itemMatch = documents.some((d) => (d.flags.ddbimporter?.chrisPreEffectName ?? ChrisPremadesHelper.getOriginalName(d)) === requiredFeature && d.type === "feat");
-          if (!itemMatch) continue;
-        }
+        const itemMatch = restrictedItem.requiredEquipment.every((requiredEquipment) => documents.some((d) => (d.flags.ddbimporter?.chrisPreEffectName ?? ChrisPremadesHelper.getOriginalName(d)) === requiredEquipment && DICTIONARY.types.inventory.includes(d.type)));
+        if (!itemMatch) continue;
       }
 
       if (restrictedItem.requiredFeatures) {
-        for (const requiredFeature of restrictedItem.requiredFeatures) {
-          const itemMatch = documents.some((d) => (d.flags.ddbimporter?.chrisPreEffectName ?? ChrisPremadesHelper.getOriginalName(d)) === requiredFeature && d.type === "feat");
-          if (!itemMatch) continue;
-        }
+        const itemMatch = restrictedItem.requiredFeatures.every((requiredFeature) => documents.some((d) => (d.flags.ddbimporter?.chrisPreEffectName ?? ChrisPremadesHelper.getOriginalName(d)) === requiredFeature && d.type === "feat"));
+        if (!itemMatch) continue;
       }
 
       // now replace the matched item with the replaced Item

--- a/src/effects/external/ChrisPremadesHelper.js
+++ b/src/effects/external/ChrisPremadesHelper.js
@@ -531,21 +531,21 @@ ${chat}
 
       if (restrictedItem.requiredEquipment) {
         for (const requiredEquipment of restrictedItem.requiredEquipment) {
-          const itemMatch = documents.some((d) => ddbName === requiredEquipment && DICTIONARY.types.inventory.includes(d.type));
+          const itemMatch = documents.some((d) => d.name === requiredEquipment && DICTIONARY.types.inventory.includes(d.type));
           if (!itemMatch) continue;
         }
       }
 
       if (restrictedItem.requiredFeature) {
         for (const requiredFeature of restrictedItem.requiredFeature) {
-          const itemMatch = documents.some((d) => ddbName === requiredFeature && d.type === "feat");
+          const itemMatch = documents.some((d) => d.name === requiredFeature && d.type === "feat");
           if (!itemMatch) continue;
         }
       }
 
       if (restrictedItem.requiredFeatures) {
         for (const requiredFeature of restrictedItem.requiredFeatures) {
-          const itemMatch = documents.some((d) => ddbName === requiredFeature && d.type === "feat");
+          const itemMatch = documents.some((d) => d.name === requiredFeature && d.type === "feat");
           if (!itemMatch) continue;
         }
       }

--- a/src/effects/external/ChrisPremadesHelper.js
+++ b/src/effects/external/ChrisPremadesHelper.js
@@ -531,21 +531,21 @@ ${chat}
 
       if (restrictedItem.requiredEquipment) {
         for (const requiredEquipment of restrictedItem.requiredEquipment) {
-          const itemMatch = documents.some((d) => d.name === requiredEquipment && DICTIONARY.types.inventory.includes(d.type));
+          const itemMatch = documents.some((d) => (d.flags.ddbimporter?.chrisPreEffectName ?? ChrisPremadesHelper.getOriginalName(d)) === requiredEquipment && DICTIONARY.types.inventory.includes(d.type));
           if (!itemMatch) continue;
         }
       }
 
       if (restrictedItem.requiredFeature) {
         for (const requiredFeature of restrictedItem.requiredFeature) {
-          const itemMatch = documents.some((d) => d.name === requiredFeature && d.type === "feat");
+          const itemMatch = documents.some((d) => (d.flags.ddbimporter?.chrisPreEffectName ?? ChrisPremadesHelper.getOriginalName(d)) === requiredFeature && d.type === "feat");
           if (!itemMatch) continue;
         }
       }
 
       if (restrictedItem.requiredFeatures) {
         for (const requiredFeature of restrictedItem.requiredFeatures) {
-          const itemMatch = documents.some((d) => d.name === requiredFeature && d.type === "feat");
+          const itemMatch = documents.some((d) => (d.flags.ddbimporter?.chrisPreEffectName ?? ChrisPremadesHelper.getOriginalName(d)) === requiredFeature && d.type === "feat");
           if (!itemMatch) continue;
         }
       }


### PR DESCRIPTION
Hi - third CPR dev here. Looks like we never made use of `requiredEquipment` or `requiredFeatures` previously. Currently it's checking `ddbName` (which'll be the name of the item we're potentially replacing) against `requiredEquipment`/`requiredFeature`, so it'll never evaluate to `true`. Fix has it comparing each item's name to the `required` name.