### PR TITLE
Updated maximum version of dnd5e system

### DIFF
--- a/module-template.json
+++ b/module-template.json
@@ -38,7 +38,7 @@
       "type": "system",
       "compatibility": {
         "minimum": "3.2.0",
-        "maximum": "3.9.0",
+        "maximum": "4.0.1",
         "verified": "3.2.0"
       }
     }]


### PR DESCRIPTION
Currently I'm unable to import characters after the auto migration ran for dnd5e system. 
It would be great if the maximum version would be incremented to it wants to be installed.