### PR TITLE
Backport change to sense.js monster parser to dnd v3.x.x branch

### DIFF
--- a/src/parser/monster/senses.js
+++ b/src/parser/monster/senses.js
@@ -58,6 +58,9 @@ DDBMonster.prototype._generateTokenSenses = function _generateTokenSenses() {
         }
         // add these modes if supported by vision 5e
         if (vision5eInstalled && blindBeyondMatch) {
+          this.npc.prototypeToken.detectionModes = this.npc.prototypeToken.detectionModes.filter((m) =>
+            m.id !== "lightPerception",
+          );
           this.npc.prototypeToken.detectionModes.push(
             {
               "id": "lightPerception",


### PR DESCRIPTION
Hi MrPrimate,
as the main ddbi release is dnd v4+ only, I have backported this fix in my local deployment. But I thought I would provide a merge request for maybe providing this fix for all the users who can't migrate to v4 because of other modules (mainly midi-qol)
It is based on the 3.x.x branch and I didn't change any module.json stuff (so version and so on needs to be changed I think)

If this isn't viable for you for any reason, don't worry and just close the merge request and don't integrate it.

Best regards