### PR TITLE
Allowing handouts to be used by non ddb-importer content

### DIFF
--- a/src/hooks.js
+++ b/src/hooks.js
@@ -101,7 +101,7 @@ export function renderJournalSheet(sheet, html, data) {
   if (data.cssClass !== "editable" && sheet.document.flags?.ddb) {
     linkTables("journal", html);
     linkImages(html, data);
-    showReadAlouds(html, data);
   }
+  showReadAlouds(html, data);
   adventureFlags(sheet, html, data);
 }


### PR DESCRIPTION
While fixing an issue for images, a condition was added which only binds some functionality if the content is imported by ddb-importer.
This removed the possibility of using the (amazing) handouts functionality for content that isn't imported.

Commit of change that impacted handouts feature: https://github.com/MrPrimate/ddb-importer/commit/c500a0719f05d198f3fc441d1b70516323eb674d