### PR TITLE
fix: add support for proxies on subpath path urls for socket connections

### DIFF
--- a/src/lib/PatreonHelper.ts
+++ b/src/lib/PatreonHelper.ts
@@ -1,10 +1,11 @@
 import logger from "./Logger";
 import utils from "./Utils";
 import DDBProxy from "./DDBProxy";
+import { parseSocketUrl } from "./streaming/ParseSocketUrl";
 import { SETTINGS } from "../config/_module";
 import DDBKeyChangeDialog from "../apps/DDBKeyChangeDialog";
 
-interface IPatreonTierResponse  {
+interface IPatreonTierResponse {
   "success": boolean;
   "message": string;
   "data": string;
@@ -36,7 +37,7 @@ let activePatreonLinkSocket: any = null;
 
 const PatreonHelper = {
 
-  isValidKey: async(local = false, setKey = true, overrideKey = null) => {
+  isValidKey: async (local = false, setKey = true, overrideKey = null) => {
     // eslint-disable-next-line no-useless-assignment
     let validKey = false;
 
@@ -197,7 +198,7 @@ const PatreonHelper = {
     return tiers;
   },
 
-  checkPatreon: async ({local = false, overrideKey = null, cacheBust = true }: { local?: boolean; overrideKey?: string | null; cacheBust?: boolean } = {}): Promise<IPatreonAccessMatrix> => {
+  checkPatreon: async ({ local = false, overrideKey = null, cacheBust = true }: { local?: boolean; overrideKey?: string | null; cacheBust?: boolean } = {}): Promise<IPatreonAccessMatrix> => {
     if (!cacheBust) {
       if (local && CONFIG.DDBI.PATREON.tiersLocal) {
         return CONFIG.DDBI.PATREON.tiersLocal;
@@ -230,11 +231,12 @@ const PatreonHelper = {
     const patreonAuthUrl = `${proxy}/patreon/auth`;
     const patreonScopes = encodeURI("identity identity[email]");
 
-    const socketOptions = {
+    const { url, path } = parseSocketUrl(proxy, "/");
+    const socket = io(url, {
+      path,
       transports: ["websocket", "polling", "flashsocket"],
       reconnection: false,
-    };
-    const socket = io(`${proxy}/`, socketOptions);
+    });
     activePatreonLinkSocket = socket;
 
     socket.once("connect", () => {

--- a/src/lib/streaming/BaseStreamSocket.ts
+++ b/src/lib/streaming/BaseStreamSocket.ts
@@ -1,5 +1,6 @@
 import type { Socket } from "socket.io-client";
 import logger from "../Logger";
+import { parseSocketUrl } from "./ParseSocketUrl";
 
 export interface BaseStreamAuthBody {
   betaKey: string;
@@ -64,8 +65,9 @@ export default abstract class BaseStreamSocket<
 
   connect(handlers?: BaseStreamHandlers<E>) {
     this.handlers = handlers ?? null;
-    const url = this.proxyUrl + this.namespace;
+    const { url, path } = parseSocketUrl(this.proxyUrl, this.namespace);
     this.socket = io(url, {
+      path,
       transports: ["websocket"],
       reconnection: true,
       reconnectionAttempts: 10,

--- a/src/lib/streaming/DDBMuleSocket.ts
+++ b/src/lib/streaming/DDBMuleSocket.ts
@@ -1,5 +1,6 @@
 import type { Socket } from "socket.io-client";
 import logger from "../Logger";
+import { parseSocketUrl } from "./ParseSocketUrl";
 
 export interface DDBMuleAuthBody {
   betaKey: string;
@@ -50,6 +51,8 @@ export interface DDBMuleHandlers {
 export default class DDBMuleSocket {
   socket: Socket | null = null;
   proxyUrl: string;
+  socketUrl: string;
+  socketPath: string | undefined;
   jobId: string | null = null;
   jobToken: string | null = null;
   lastSeq = 0;
@@ -58,12 +61,15 @@ export default class DDBMuleSocket {
 
   constructor(proxyUrl: string) {
     this.proxyUrl = proxyUrl.replace(/\/$/, "");
+    const { url, path } = parseSocketUrl(this.proxyUrl, "/mule");
+    this.socketUrl = url;
+    this.socketPath = path;
   }
 
   connect(handlers: DDBMuleHandlers) {
     this.handlers = handlers;
-    const url = this.proxyUrl + "/mule";
-    this.socket = io(url, {
+    this.socket = io(this.socketUrl, {
+      path: this.socketPath,
       transports: ["websocket"],
       reconnection: true,
       reconnectionAttempts: 10,

--- a/src/lib/streaming/ParseSocketUrl.ts
+++ b/src/lib/streaming/ParseSocketUrl.ts
@@ -1,0 +1,10 @@
+export function parseSocketUrl(proxyUrl: string, nsp: string): { url: string; path: string | undefined } {
+  try {
+    const { origin, pathname } = new URL(proxyUrl);
+    const prefix = pathname.replace(/\/$/, "");
+    if (prefix) {
+      return { url: origin + nsp, path: prefix + "/socket.io" };
+    }
+  } catch { /* ignore - not a valid URL */ }
+  return { url: proxyUrl + nsp, path: undefined };
+}

--- a/tests/lib/ParseSocketUrl.test.ts
+++ b/tests/lib/ParseSocketUrl.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { parseSocketUrl } from "../../src/lib/streaming/ParseSocketUrl";
+
+describe("parseSocketUrl", () => {
+  it("returns url with namespace appended when no subpath", () => {
+    const result = parseSocketUrl("https://proxy.ddb.mrprimate.co.uk", "/monsters");
+    expect(result).toEqual({
+      url: "https://proxy.ddb.mrprimate.co.uk/monsters",
+      path: undefined,
+    });
+  });
+
+  it("extracts subpath into socket.io path option", () => {
+    const result = parseSocketUrl("https://vtt.example.com/ddb-proxy", "/monsters");
+    expect(result).toEqual({
+      url: "https://vtt.example.com/monsters",
+      path: "/ddb-proxy/socket.io",
+    });
+  });
+
+  it("strips trailing slash from subpath", () => {
+    const result = parseSocketUrl("https://vtt.example.com/ddb-proxy/", "/mule");
+    expect(result).toEqual({
+      url: "https://vtt.example.com/mule",
+      path: "/ddb-proxy/socket.io",
+    });
+  });
+
+  it("handles root namespace with subpath", () => {
+    const result = parseSocketUrl("https://vtt.example.com/ddb-proxy", "/");
+    expect(result).toEqual({
+      url: "https://vtt.example.com/",
+      path: "/ddb-proxy/socket.io",
+    });
+  });
+
+  it("falls back to simple concatenation for invalid URL", () => {
+    const result = parseSocketUrl("not-a-url", "/monsters");
+    expect(result).toEqual({
+      url: "not-a-url/monsters",
+      path: undefined,
+    });
+  });
+
+  it("handles deeply nested subpath", () => {
+    const result = parseSocketUrl("https://services.example.com/api/v2/proxy", "/spells");
+    expect(result).toEqual({
+      url: "https://services.example.com/spells",
+      path: "/api/v2/proxy/socket.io",
+    });
+  });
+});


### PR DESCRIPTION
## Background

My foundry vtt is on a personal domain (eg: `https://foundry.aerilym.com`) reverse proxied with nginx, so I also wanted to put ddb-proxy on a subpath of that domain (eg: `https://foundry.aerilym.com/ddb-proxy`).

This worked initially for the cobalt cookie check and ping, but when I went to "Monster Munch" I got a socket.io namespace error: `Logger.ts:88 DDB Importer | WARN > [DDBMonsterSocket] connect_error: Invalid namespace`

## Problem

Socket.IO clients were connecting with the proxy URL's subpath as the namespace (e.g., `/ddb-proxy/monsters`) instead of just the intended namespace (`/monsters`).

## Solution

Added a utility function to properly parse proxy urls. This handles proxy URLs containing a subpath (e.g., `https://foundry.aerilym.com/ddb-proxy`), and uses Socket.IO's `path` option to route through the subpath (`/ddb-proxy/socket.io`) while connecting to the correct namespace (`/monsters`). URLs without a subpath are unaffected.

I've tested this change on my own foundryvtt setup and I was able to use "monster munch".