### PR TITLE
chore: typescript improvements - remove easy to cleanup 'as any' casts

### DIFF
--- a/src/apps/DDBCharacterManager.ts
+++ b/src/apps/DDBCharacterManager.ts
@@ -215,11 +215,11 @@ export default class DDBCharacterManager extends DDBAppV2 {
 
     this.element.querySelector("#open-dndbeyond-url")?.addEventListener("click", async () => {
       try {
-        const characterUrl = (this.actor.flags as IActorFlagConfig).ddbimporter?.dndbeyond?.url;
+        const characterUrl = this.actor.flags?.ddbimporter?.dndbeyond?.url;
         if (!characterUrl) throw new Error("No D&D Beyond URL set on actor");
         DDBCharacterManager.renderPopup("json", characterUrl);
       } catch (error) {
-        this.showCurrentTask("Error opening JSON URL", { message: error, isError: true });
+        this.showCurrentTaskError("Error opening JSON URL", { error, supressLog: true });
       }
     });
 
@@ -319,12 +319,35 @@ export default class DDBCharacterManager extends DDBAppV2 {
     return context;
   }
 
-
-  showCurrentTask(title: string, { message = null as any, isError = false } = {}) {
+  showCurrentTask(title: string, { message = null, isError = false }: { message?: string | boolean | null; isError?: boolean } = {}) {
     logger.debug("DDBCharacterManager: showCurrentTask", { title, message, isError });
     const element = $(this.element).find(".task-name");
     element.html(`<h2 ${isError ? " style='color:red'" : ""}>${title}</h2>${message ? `<p>${message}</p>` : ""}`);
     $(this.element).parent().parent().css("height", "auto");
+  }
+
+  // TODO: supressLog is here as an option for the few places that didnt call logger.error for errors before, if
+  // we always want errors to log we can remove this option.
+  showCurrentTaskError(title: string, { error = null, supressLog = false }: { error: unknown; supressLog?: boolean }) {
+    if (!supressLog) {
+      logger.error(error);
+    }
+
+    let message = "Unknown Error";
+    if (error && typeof error === "object") {
+      if (!supressLog && "stack" in error && error.stack) {
+        logger.error(error.stack);
+      }
+      // NOTE: we could use instanceOf, but this allows us to handle any error-like
+      // object with a 'message' attribute. Great for custom errors and errors from
+      // 3rd party sources that aren't properly constructed.
+      if ("message" in error && error.message && typeof error.message == "string") {
+        message = error.message;
+      }
+    } else if (error && typeof error === "string") {
+      message = error;
+    }
+    this.showCurrentTask(title, { message, isError: true });
   }
 
 
@@ -418,9 +441,7 @@ export default class DDBCharacterManager extends DDBAppV2 {
         }).render({ force: true });
       }
     } catch (error) {
-      logger.error(error);
-      if (error instanceof Error) logger.error(error.stack);
-      this.showCurrentTask("Error setting local patreon key", { message: error, isError: true });
+      this.showCurrentTaskError("Error setting local patreon key", { error });
     }
   }
 
@@ -435,9 +456,7 @@ export default class DDBCharacterManager extends DDBAppV2 {
         this.#setText("#dndbeyond-character-update", "D&D Beyond Update Available to Patreon Supporters");
       }
     } catch (error) {
-      logger.error(error);
-      if (error instanceof Error) logger.error(error.stack);
-      this.showCurrentTask("Error deleting local cookie", { message: error, isError: true });
+      this.showCurrentTaskError("Error deleting local cookie", { error });
     }
   }
 
@@ -452,9 +471,7 @@ export default class DDBCharacterManager extends DDBAppV2 {
         },
       }).render(true);
     } catch (error) {
-      logger.error(error);
-      if (error instanceof Error) logger.error(error.stack);
-      this.showCurrentTask("Error setting local cookie", { message: error, isError: true });
+      this.showCurrentTaskError("Error setting local cookie", { error });
     }
   }
 
@@ -464,9 +481,7 @@ export default class DDBCharacterManager extends DDBAppV2 {
       this.#setDisabled("#delete-local-cobalt", true);
       this.#setText("#set-local-cobalt", "Add Cobalt Cookie");
     } catch (error) {
-      logger.error(error);
-      if (error instanceof Error) logger.error(error.stack);
-      this.showCurrentTask("Error deleting local cookie", { message: error, isError: true });
+      this.showCurrentTaskError("Error deleting local cookie", { error });
     }
   }
 
@@ -490,9 +505,7 @@ export default class DDBCharacterManager extends DDBAppV2 {
         this.#setDisabled("#dndbeyond-character-update", false);
       });
     } catch (error) {
-      logger.error(error);
-      if (error instanceof Error) logger.error(error.stack);
-      this.showCurrentTask("Error updating character", { message: error, isError: true });
+      this.showCurrentTaskError("Error updating character: ", { error });
     }
   }
 
@@ -541,12 +554,10 @@ export default class DDBCharacterManager extends DDBAppV2 {
           logger.error("Failure");
           break;
         case "Forbidden":
-          this.showCurrentTask("Error retrieving Character: " + error, { message: error, isError: true });
+          this.showCurrentTaskError("Error retrieving Character: ", { error, supressLog: true });
           break;
         default:
-          logger.error(error);
-          if (error instanceof Error) logger.error(error.stack);
-          this.showCurrentTask("Error processing Character: " + error, { message: error, isError: true });
+          this.showCurrentTaskError("Error processing Character: ", { error });
           break;
       }
       return;
@@ -570,12 +581,10 @@ export default class DDBCharacterManager extends DDBAppV2 {
           logger.error("Failure", { ddbCharacter: this.ddbCharacter, result: this.result });
           break;
         case "Forbidden":
-          this.showCurrentTask("Error retrieving Character: " + error, { message: error, isError: true });
+          this.showCurrentTaskError("Error retrieving Character: ", { error, supressLog: true });
           break;
         default:
-          logger.error(error);
-          if (error instanceof Error) logger.error(error.stack);
-          this.showCurrentTask("Error processing Character: " + error, { message: error, isError: true });
+          this.showCurrentTaskError("Error processing Character: ", { error });
           logger.error("Failure", { ddbCharacter: this.ddbCharacter, result: this.result });
           break;
       }

--- a/src/apps/DDBPartySync.ts
+++ b/src/apps/DDBPartySync.ts
@@ -352,9 +352,9 @@ export default class DDBPartySync extends DDBAppV2 {
     }
   }
 
-  static _findOwnerActor(ddbCharacterId: number): any | null {
+  static _findOwnerActor(ddbCharacterId: number) {
     if (!Number.isInteger(ddbCharacterId)) return null;
-    return ((game as any).actors as any[]).find((a) => {
+    return game.actors?.find((a) => {
       if (a.type !== "character") return false;
       const id = parseInt(`${foundry.utils.getProperty(a, "flags.ddbimporter.dndbeyond.characterId") ?? ""}`);
       return id === ddbCharacterId;
@@ -481,13 +481,14 @@ export default class DDBPartySync extends DDBAppV2 {
     ui.notifications?.info(`Updating ${targets.length} character(s) to DDB...`);
     let updated = 0;
     for (const c of targets) {
-      const actor = (game as any).actors.get(c.worldActorId);
+      const actor = game.actors?.get(c.worldActorId!);
       if (!actor) {
         logger.warn(`No actor found for ${c.characterName} (${c.worldActorId})`);
         continue;
       }
       try {
-        await updateDDBCharacter(actor);
+        // TODO: Create 'isTSyncCharacterActor' type guard to replace 'as' cast
+        await updateDDBCharacter(actor as TSyncCharacterActor);
         updated += 1;
       } catch (err) {
         logger.error(`Failed to update ${c.characterName} (${c.characterId}) to DDB`, err);

--- a/src/effects/DDBEffectHelper.ts
+++ b/src/effects/DDBEffectHelper.ts
@@ -1646,10 +1646,10 @@ export default class DDBEffectHelper {
 
   static async _conditionRemovalMidiRoll(targetToken: Token.Implementation, condition: string, {
     document = null,
-    activity = null as any,
-    type = null as string | null, // can be save or check, if null, will check flags
-    ability = null as string | null, // e.g. wis, if null, will check flags
-    saveDC = null as number | null, // if null, will use activity if present, otherwise spelldc
+    activity = null,
+    type = null, // can be save or check, if null, will check flags
+    ability = null, // e.g. wis, if null, will check flags
+    saveDC = null, // if null, will use activity if present, otherwise spelldc
   }: {
     document?: Item.Implementation | null;
     activity?: IRemovalActivity | null;

--- a/src/effects/external/ChrisPremadesHelper.ts
+++ b/src/effects/external/ChrisPremadesHelper.ts
@@ -255,7 +255,7 @@ export default class ChrisPremadesHelper {
       this.document.img = chrisDoc.img;
     }
 
-    const correctionProperties = foundry.utils.getProperty(CONFIG, `chrisPremades.correctedItems.${this.chrisName}`) as unknown as any;
+    const correctionProperties = foundry.utils.getProperty(CONFIG, `chrisPremades.correctedItems.${this.chrisName}`) as unknown as Record<string, unknown>;
     if (correctionProperties) {
       logger.debug(`Updating ${this.original.name} with a CPR correction properties`);
       this.document = foundry.utils.mergeObject(this.document, correctionProperties) as typeof this.document;
@@ -420,7 +420,7 @@ export default class ChrisPremadesHelper {
       }
       if (restrictedItem.requiredRace
         && restrictedItem.requiredRace.toLocaleLowerCase()
-          !== ((foundry.utils.getProperty(rollData, "details.race.name") as string) ?? (foundry.utils.getProperty(rollData, "details.race") as string))?.toLocaleLowerCase()
+        !== ((foundry.utils.getProperty(rollData, "details.race.name") as string) ?? (foundry.utils.getProperty(rollData, "details.race") as string))?.toLocaleLowerCase()
       ) continue;
 
 
@@ -475,7 +475,7 @@ export default class ChrisPremadesHelper {
         const docAdd = documents.find((d) => d.name === ddbName);
         if (docAdd) {
           for (const newItem of restrictedItem.additionalItems) {
-            const {name: newItemName = newItem, type: typeOverride} = newItem;
+            const { name: newItemName = newItem, type: typeOverride } = newItem;
             logger.debug(`Adding new item ${newItemName}`);
             const chrisDoc = await ChrisPremadesHelper.getDocumentFromName({
               documentName: newItemName,

--- a/src/lib/SqliteCipher.ts
+++ b/src/lib/SqliteCipher.ts
@@ -53,7 +53,7 @@ let _sqlite3: any = null;
 const nativeImport = new Function("url", "return import(url);") as (url: string) => Promise<any>;
 
 function moduleUrl(relPath: string): string {
-  const getRoute = (globalThis as any).foundry?.utils?.getRoute;
+  const getRoute = globalThis?.foundry?.utils?.getRoute;
   const routed = getRoute ? getRoute(relPath) : `/${relPath}`;
   return `${globalThis.location.origin}${routed}`;
 }

--- a/src/muncher/DDBPartyInventoryImporter.ts
+++ b/src/muncher/DDBPartyInventoryImporter.ts
@@ -18,7 +18,7 @@ export default class DDBPartyInventoryImporter {
     name = null,
     create = true,
   }: { campaignId: string; name?: string | null; create?: boolean }) {
-    const existing = (game as any).actors.find((a: any) =>
+    const existing = game.actors?.find((a) =>
       a.type === "group"
       && foundry.utils.getProperty(a, `flags.${FLAG_SCOPE}.${FLAG_CAMPAIGN_KEY}`) === campaignId,
     );

--- a/src/muncher/spells.ts
+++ b/src/muncher/spells.ts
@@ -203,8 +203,23 @@ async function streamAllClassSpells({ sourceFilter, searchFilter, sourcesOverrid
 // path first; on connect/auth/start failure fall through to the HTTP endpoint.
 let _spellSocketDisabled = false;
 
-export async function parseSpells({ ids = null as any, deleteBeforeUpdate = null as any, notifier = null as any, notifierV2 = null as any, searchFilter = null as any, sources = null as any } = {}) {
+interface IParseSpellsOptions {
+  ids?: (string | number)[] | null;
+  deleteBeforeUpdate?: boolean | null;
+  notifier?: NotifierV1 | null;
+  notifierV2?: INotifierV2 | null;
+  searchFilter?: string | null;
+  sources?: number[] | null;
+}
 
+export async function parseSpells({
+  ids = null,
+  deleteBeforeUpdate = null,
+  notifier = null,
+  notifierV2 = null,
+  searchFilter = null,
+  sources = null,
+}: IParseSpellsOptions = {}) {
   await DDBReferenceLinker.importCacheLoad();
   const updateBool = utils.getSetting<boolean>("munching-policy-update-existing");
   const uploadDirectory = utils.getSetting<string>("other-image-upload-directory").replace(/^\/|\/$/g, "");
@@ -231,7 +246,7 @@ export async function parseSpells({ ids = null as any, deleteBeforeUpdate = null
   let classSpellSets: ClassSpellSet[] | null = null;
   if (!_spellSocketDisabled) {
     try {
-      classSpellSets = await streamAllClassSpells({ sourceFilter, searchFilter, sourcesOverride: sources });
+      classSpellSets = await streamAllClassSpells({ sourceFilter, searchFilter: searchFilter ?? "", sourcesOverride: sources });
     } catch (err) {
       logger.warn(`[spells] streaming failed, falling back to HTTP: ${(err as Error)?.message ?? String(err)}`);
       _spellSocketDisabled = true;
@@ -251,7 +266,7 @@ export async function parseSpells({ ids = null as any, deleteBeforeUpdate = null
           sourceFilter,
           notifier: resolvedNotifier,
           rulesVersion,
-          searchFilter,
+          searchFilter: searchFilter ?? "",
           sourcesOverride: sources,
         });
         spellListFactory.extractClassSpellListData(className, spellData);

--- a/src/parser/DDBEncounterFactory.ts
+++ b/src/parser/DDBEncounterFactory.ts
@@ -9,14 +9,11 @@ export default class DDBEncounterFactory {
   encountersData: IDDBEncounter[];
   encounters: Record<string, DDBEncounter>;
 
-  constructor({ notifier = null as any } = {}) {
-    this.notifier = notifier;
+  constructor({ notifier = null }: { notifier?: NotifierV1 | null } = {}) {
+    this.notifier = notifier ?? ((note, { nameField = false, monsterNote = false, message = false, isError = false } = {}) => {
+      logger.info(note, { nameField, monsterNote, message, isError });
+    }) satisfies NotifierV1;
 
-    if (!notifier) {
-      this.notifier = (note, { nameField = false, monsterNote = false, message = false, isError = false } = {}) => {
-        logger.info(note, { nameField, monsterNote, message, isError });
-      };
-    }
     this.encountersData = [];
     this.encounters = {};
   }

--- a/src/parser/DDBMonster.ts
+++ b/src/parser/DDBMonster.ts
@@ -10,6 +10,18 @@ export interface IDDBMonsterOverrides {
   [key: string]: any;
 }
 
+interface IDDBMonsterConstructorOptions {
+  existingNpc?: TParsedMonsterData | null;
+  extra?: boolean;
+  useItemAC?: boolean;
+  legacyName?: boolean;
+  addMonsterEffects?: boolean;
+  addChrisPremades?: boolean;
+  use2024Spells?: boolean | null;
+  useCastActivity?: boolean | null;
+  forceRulesVersion?: string | null;
+}
+
 // Declaration merging: these methods are added to DDBMonster.prototype
 // by the files imported via extendParsers.ts
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -102,9 +114,9 @@ class DDBMonster {
   is2014!: boolean;
   is2024!: boolean;
   legacy!: boolean;
-  use2024Spells: boolean;
-  useCastActivity: boolean;
-  forceRulesVersion: boolean;
+  use2024Spells: boolean | null;
+  useCastActivity: boolean | null;
+  forceRulesVersion: string | null;
   extra: boolean;
   spellcasting: {
     spelldc: number;
@@ -142,15 +154,18 @@ class DDBMonster {
     }
   }
 
-  constructor(ddbObject: any = null, { existingNpc = null as any, extra = false, useItemAC = true,
-    legacyName = true, addMonsterEffects = false, addChrisPremades = false, use2024Spells = null as any,
-    useCastActivity = null as any, forceRulesVersion = null as any } = {}, overrides: IDDBMonsterOverrides = {},
+  constructor(ddbObject: any = null, { existingNpc = null, extra = false, useItemAC = true,
+    legacyName = true, addMonsterEffects = false, addChrisPremades = false, use2024Spells = null,
+    useCastActivity = null, forceRulesVersion = null }: IDDBMonsterConstructorOptions = {}, overrides: IDDBMonsterOverrides = {},
   ) {
     this.source = ddbObject;
 
     // processing options
     this.extra = extra;
-    this.npc = existingNpc;
+    // TODO: this is a bit dangerous as the object type says npc is defined, but it can be null here. It currently works
+    // fine because the two DDBMonstor constructor sites define this after construction (manually and via .parse(), this
+    // can probably be cleaned up a bit more.
+    this.npc = existingNpc as TParsedMonsterData;
     this.useItemAC = useItemAC;
     this.legacyName = legacyName;
     this.addMonsterEffects = addMonsterEffects;
@@ -166,7 +181,7 @@ class DDBMonster {
     this.characterDescription = "";
 
     // processing info
-    this.name = overrides["name"] ?? (existingNpc ? existingNpc.name : null);
+    this.name = (overrides["name"] ?? (existingNpc ? existingNpc.name : null)) ?? "";
     this.proficiencyBonus = null;
     this.cr = {
       "id": 1,
@@ -181,8 +196,8 @@ class DDBMonster {
       this.setProperty("proficiencyBonus", existingNpc.system.attributes.prof);
       this.setProperty("cr", existingNpc.system.details.cr);
       this.setProperty("abilities", existingNpc.system.abilities);
-      this.items = foundry.utils.duplicate(existingNpc.items);
-      this.img = existingNpc.img;
+      this.items = foundry.utils.duplicate(existingNpc.items) as unknown as I5eMonsterItem[];
+      this.img = existingNpc.img ?? null;
     }
     this.stockImage = false;
 

--- a/src/parser/activities/DDBBasicActivity.ts
+++ b/src/parser/activities/DDBBasicActivity.ts
@@ -640,14 +640,13 @@ export default class DDBBasicActivity {
   }
 
   static async addQuickCastActivity({ uuid, actor, document, spellOverride = null, consumptionTargetOverrides = null, activityData = {}, nameIdPostfix = null }: { uuid?: string; actor?: any; document?: any; spellOverride?: any; consumptionTargetOverrides?: any; activityData?: any; nameIdPostfix?: string | null } = {}): Promise<string | null> {
-    const foundryData = document.toObject();
-    const spellData = await (globalThis as any).fromUuid(uuid);
-
+    const spellData = await fromUuid(uuid);
     if (!spellData) {
       (ui as any).notifications.error(`Could not find spell with UUID: ${uuid}`);
       return null;
     }
 
+    const foundryData = document.toObject();
     const ddbActivityId = await DDBBasicActivity.createActivity(
       {
         type: DDBEnricherData.ACTIVITY_TYPES.CAST,

--- a/src/parser/character/bio.ts
+++ b/src/parser/character/bio.ts
@@ -105,21 +105,21 @@ function getBackgroundTemplate(): IDDBGeneratedBackground {
   return {
     name: "Background",
     description: "",
-    id: null as any as any,
-    entityTypeId: null as any as any,
-    featuresId: null as any as any,
-    featuresEntityTypeId: null as any as any,
-    characteristicsId: null as any as any,
-    characteristicsEntityTypeId: null as any as any,
+    id: null,
+    entityTypeId: null,
+    featuresId: null,
+    featuresEntityTypeId: null,
+    characteristicsId: null,
+    characteristicsEntityTypeId: null,
     definition: {
       name: "Background",
       description: "",
-      originalDescription: null as any as any,
-      id: null as any as any,
-      entityTypeId: null as any as any,
-      sources: null as any as any,
+      originalDescription: null,
+      id: null,
+      entityTypeId: null,
+      sources: null,
     },
-  };
+  } satisfies IDDBGeneratedBackground;
 }
 
 export function generateBackground(bg: IDDBBackgroundInput): IDDBGeneratedBackground {

--- a/src/parser/enrichers/class/artificer/ArcanePrototype.ts
+++ b/src/parser/enrichers/class/artificer/ArcanePrototype.ts
@@ -167,7 +167,7 @@ export default class ArcanePrototype extends DDBEnricherData {
       uuid: spellUuid,
       properties: ["vocal", "somatic"],
       level: imbuedLevel,
-      challenge: { attack: null as any, save: null as any, override: false },
+      challenge: { attack: undefined, save: undefined, override: false },
       spellbook: false,
     };
 

--- a/src/parser/lib/DDBDescriptions.ts
+++ b/src/parser/lib/DDBDescriptions.ts
@@ -133,7 +133,7 @@ export default class DDBDescriptions {
     // minutes
     if (match[7]
       && (match[7].includes("until the end of its next turn")
-      || match[7].includes("until the end of the target's next turn"))
+        || match[7].includes("until the end of the target's next turn"))
     ) {
       durations.push("turnEnd");
     } else if (match[7] && match[7].includes("until the start of the")) {
@@ -146,12 +146,12 @@ export default class DDBDescriptions {
     return effect;
   }
 
-  static getRiderStatusEffects({ text, condition } : { text: string; condition: string }) {
+  static getRiderStatusEffects({ text, condition }: { text: string; condition: string }) {
     const checkReg = new RegExp(`While ${condition}, the target has the (.*) condition`, "i");
     const match = checkReg.exec(text);
     if (match) {
       const processedCondition = DDBDescriptions.getConditionInfo(match[1]);
-      return [processedCondition.condition];
+      return processedCondition.condition ? [processedCondition.condition] : [];
     }
     return [];
   }
@@ -187,7 +187,7 @@ export default class DDBDescriptions {
   // DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the target is also unconscious while poisoned in this way. The target wakes up if it takes damage or if another creature takes an action to shake it awake.
 
 
-  static dcParser({ text } : { text: string }): IDCParserResult {
+  static dcParser({ text }: { text: string }): IDCParserResult {
     const results: IDCParserResult = {
       save: {
         dc: {
@@ -334,12 +334,24 @@ export default class DDBDescriptions {
     return results;
   }
 
-  static getConditionInfo(condition: string, hint?: string) {
-    const result = {
+  static getConditionInfo(condition: string, hint?: string): {
+    success: boolean;
+    condition: string | null;
+    group4: boolean | null;
+    group4Condition: IDDBDamageAdjustment | null;
+    conditionName: string;
+  } {
+    const result: {
+      success: boolean;
+      condition: string | null;
+      group4: boolean | null;
+      group4Condition: IDDBDamageAdjustment | null;
+      conditionName: string;
+    } = {
       success: true,
-      condition: null as any as any,
-      group4: null as any as any,
-      group4Condition: null as any as any,
+      condition: null,
+      group4: null,
+      group4Condition: null,
       conditionName: utils.capitalize(condition),
     };
     result.condition = condition.toLowerCase();
@@ -353,7 +365,7 @@ export default class DDBDescriptions {
         )
       : undefined;
     if (group4Condition) {
-      result.condition = group4Condition.foundryValue;
+      result.condition = group4Condition.foundryValue ?? null;
       result.group4 = true;
       result.group4Condition = group4Condition;
       result.conditionName = group4Condition.name;
@@ -367,7 +379,7 @@ export default class DDBDescriptions {
     return result;
   }
 
-  static parseStatusCondition({ text } : { text: string }): IParseStatusConditionResult {
+  static parseStatusCondition({ text }: { text: string }): IParseStatusConditionResult {
     const result: IParseStatusConditionResult = {
       success: false,
       check: false,
@@ -442,7 +454,7 @@ export default class DDBDescriptions {
   }
 
 
-  static featureBasics({ text } : { text: string }): IFeatureBasicsResult {
+  static featureBasics({ text }: { text: string }): IFeatureBasicsResult {
 
     const standardMatchRegex = /(?<range>Melee|Ranged|Melee\s+or\s+Ranged)\s+(?<type>|Weapon|Spell)\s*(?<attackRoll>Attack|Attack Roll):\s*(?<bonus>[+-]\d+|your (?:\w+\s*)*)\s*(?<pb>plus PB\s|\+ PB\s)?(?:to\s+hit|,|\(|\.)/i;
     const standardAttackMatches = standardMatchRegex.exec(text);

--- a/src/parser/lib/types.d.ts
+++ b/src/parser/lib/types.d.ts
@@ -20,7 +20,7 @@ global {
     save: Omit<I5eActivitySave, "ability"> & { ability: string[] | null };
     condition: string | null;
     group4: boolean | null;
-    group4Condition: IDDBConfigDamageAdjustment | null;
+    group4Condition: IDDBDamageAdjustment | null;
     conditionName: string | null;
     duration: {
       value: number | null;

--- a/src/parser/monster/features/DDBMonsterFeature.ts
+++ b/src/parser/monster/features/DDBMonsterFeature.ts
@@ -294,7 +294,7 @@ export default class DDBMonsterFeature extends DDBActivityFactoryMixin<TDDBMonst
     };
   }
 
-  constructor(name: string, { ddbMonster, html, type, titleHTML, fullName, actionCopy, updateExisting, hideDescription, sort } : IDDBMonsterFeature) {
+  constructor(name: string, { ddbMonster, html, type, titleHTML, fullName, actionCopy, updateExisting, hideDescription, sort }: IDDBMonsterFeature) {
 
     // a missing monster previously blew up further down with a TypeError; fail loudly instead
     if (!ddbMonster) {
@@ -314,8 +314,8 @@ export default class DDBMonsterFeature extends DDBActivityFactoryMixin<TDDBMonst
     this.is2014 = ddbMonster.is2014;
     this.is2024 = !this.is2014;
     this.legacy = ddbMonster.legacy;
-    this.useCastActivity = ddbMonster.useCastActivity;
-    this.use2024Spells = ddbMonster.use2024Spells;
+    this.useCastActivity = ddbMonster.useCastActivity ?? false;
+    this.use2024Spells = ddbMonster.use2024Spells ?? false;
 
     this.type = type ?? "action";
     this.html = html ?? "";
@@ -607,10 +607,10 @@ export default class DDBMonsterFeature extends DDBActivityFactoryMixin<TDDBMonst
   }
 
   checkAbility(abilitiesToCheck: T5eAbility[]) {
-    const result = {
+    const result: { success: boolean; ability: T5eAbility | null; proficient: boolean | null } = {
       success: false,
-      ability: null as any as any,
-      proficient: null as any as any,
+      ability: null,
+      proficient: null,
     };
 
     for (const ability of abilitiesToCheck) {
@@ -682,7 +682,7 @@ export default class DDBMonsterFeature extends DDBActivityFactoryMixin<TDDBMonst
       }
       const strMod = utils.calculateModifier(this.ddbMonster.abilities["str"].value ?? 10);
       const dexMod = utils.calculateModifier(this.ddbMonster.abilities["dex"].value ?? 10);
-      const versatileWeapon = this.actionData.properties.ver &&  dexMod > strMod;
+      const versatileWeapon = this.actionData.properties.ver && dexMod > strMod;
       if (versatileWeapon || weaponLookup.actionType == "rwak") {
         weaponAbilities = ["dex"];
       } else if (weaponLookup.actionType == "mwak") {
@@ -732,7 +732,7 @@ export default class DDBMonsterFeature extends DDBActivityFactoryMixin<TDDBMonst
       const checkInitialAbilities = this.checkAbility(initialAbilities);
       if (checkInitialAbilities.success) {
         this.actionData.baseAbility = checkInitialAbilities.ability;
-        this.actionData.proficient = checkInitialAbilities.proficient;
+        this.actionData.proficient = checkInitialAbilities.proficient ?? false;
       }
 
       // okay lets see if its one of the others then!
@@ -740,7 +740,7 @@ export default class DDBMonsterFeature extends DDBActivityFactoryMixin<TDDBMonst
         const checkAllAbilities = this.checkAbility(abilities);
         if (checkAllAbilities.success) {
           this.actionData.baseAbility = checkAllAbilities.ability;
-          this.actionData.proficient = checkAllAbilities.proficient;
+          this.actionData.proficient = checkAllAbilities.proficient ?? false;
         }
       }
 
@@ -1496,9 +1496,9 @@ ${this.data.system.description.value}
   }
 
   #getSpellcastingData(): IMonsterSpellcastingData {
-    const result = {
-      dc: null as any as any,
-      ability: null as any, // ability associated
+    const result: IMonsterSpellcastingData = {
+      dc: null,
+      ability: null, // ability associated
       material: true,
       innateMatch: false,
       concentration: true,

--- a/src/updater/character.ts
+++ b/src/updater/character.ts
@@ -63,7 +63,7 @@ function pruneRecentEvents(map: Map<number, { ts: number }>) {
 
 function findPartyActorContainingDDBItem(ddbItemId: number) {
   if (!ddbItemId) return null;
-  for (const actor of (game as any).actors) {
+  for (const actor of game.actors ?? []) {
     if (actor.type !== "group") continue;
     if (!foundry.utils.getProperty(actor, `flags.ddbimporter.${PARTY_CAMPAIGN_FLAG}`)) continue;
     const match = actor.items.find((i: any) => foundry.utils.getProperty(i, "flags.ddbimporter.id") === ddbItemId);
@@ -74,7 +74,7 @@ function findPartyActorContainingDDBItem(ddbItemId: number) {
 
 function findCharacterOwningDDBItem(ddbItemId: number) {
   if (!ddbItemId) return null;
-  for (const actor of (game as any).actors) {
+  for (const actor of game.actors ?? []) {
     if (actor.type !== "character") continue;
     const match = actor.items.find((i: any) => foundry.utils.getProperty(i, "flags.ddbimporter.id") === ddbItemId);
     if (match) return { actor, item: match };


### PR DESCRIPTION
## Summary

TypeScript cleanup pass removing easy to cleanup `as any` casts and a new `showCurrentTaskError` helper in `DDBCharacterManager` for consistent error handling in catch blocks.

## Changes

- Replace `as any` / `null as any` casts with typed values across parser, apps, effects, and muncher modules
- Add `showCurrentTaskError` helper handling object, string, and unknown error shapes
- Null-guard `(game as any).actors` accesses with `game.actors ?? []` / `game.actors?.find(...)`
- Reorder `addQuickCastActivity` null check before `toObject()` call
