### PR TITLE
Fix: 2024 Rogue missing Expertise advancement at level 6

### DIFF
--- a/src/parser/classes/DDBBaseClass.ts
+++ b/src/parser/classes/DDBBaseClass.ts
@@ -1421,16 +1421,45 @@ export default abstract class DDBBaseClass {
     this._addAdvancements(advancements);
   }
 
+  _parseExpertiseAdditionalLevels(description: string): number[] {
+    const text = utils.stripHtml(description);
+    const regex = /At \w+ level (\d+)/gi;
+    const levels: number[] = [];
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      levels.push(parseInt(match[1]));
+    }
+    return levels;
+  }
+
   _generateExpertiseAdvancements() {
     const advancements: I5eAdvancement[] = [];
+    const handledLevels = new Set<number>();
 
     for (let i = 0; i <= 20; i++) {
       const expertiseFeature = this._expertiseFeatures.find((f) => f.requiredLevel === i);
 
       if (!expertiseFeature) continue;
 
+      handledLevels.add(i);
       const advancement = this.advancementHelper.getExpertiseAdvancement(expertiseFeature, i);
       if (advancement) advancements.push(advancement.toObject() as I5eAdvancement);
+    }
+
+    // For 2024 rules, a single "Expertise" feature may describe grants at additional levels
+    // (e.g. Rogue's level-1 Expertise says "At Rogue level 6, you gain Expertise in two more...").
+    // DDB only has one feature entry in this case, so we parse the description to find the extra levels.
+    if (!this.is2014) {
+      for (const expertiseFeature of this._expertiseFeatures) {
+        if (expertiseFeature.name !== "Expertise") continue;
+        const extraLevels = this._parseExpertiseAdditionalLevels(expertiseFeature.description ?? "");
+        for (const level of extraLevels) {
+          if (handledLevels.has(level)) continue;
+          handledLevels.add(level);
+          const advancement = this.advancementHelper.getExpertiseAdvancement(expertiseFeature, level);
+          if (advancement) advancements.push(advancement.toObject() as I5eAdvancement);
+        }
+      }
     }
 
     this._addAdvancements(advancements);


### PR DESCRIPTION
I noticed when re-building one of my player's characters that the rogue wasn't being granted Expertise at 6th level. After looking at what was in dndbeyond it seemed like there was a single feature at level 1 that says 
```
Level 1: Expertise
You gain Expertise in two of your skill proficiencies of your choice.

At Rogue level 6, you gain Expertise in two more of your skill proficiencies of your choice.
```
So I figured ddb-importer was seeing the single level 1 feature and never knowing it needed to create an advancement at level 6 for more Expertise.

This is probably overkill (I'm not sure if anything else grants expertise in the same way that would have a level other than level 6) but this checks the expertise feature to figure out what levels additional levels would need to be granted expertise.

Scoped to 2024/5.5e because as far as I can tell the 2014 version lists a feature at 1st and 6th level.

Feel free to close this if you'd rather implement yourself some other way. I just had some extra time on my hands and noticed this issue so figured I'd see how I might fix it.

Before:
<img width="953" height="639" alt="image" src="https://github.com/user-attachments/assets/af2fa702-d52d-435d-a8de-4c8873089757" />

After:
<img width="994" height="587" alt="image" src="https://github.com/user-attachments/assets/bdc57ab6-cfce-4d63-ba93-32105ea7fd51" />
